### PR TITLE
feat: 외부 DarkerDB API 라우팅용 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-    implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
-
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     container_name: dad-marketplace-app
     ports:
       - "8080:8080"
+      - "8443:8443"
     environment:
       - SPRING_PROFILES_ACTIVE=docker
       - MYSQL_HOST=mysql
@@ -19,7 +20,8 @@ services:
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID}
       - DISCORD_CLIENT_SECRET=${DISCORD_CLIENT_SECRET}
-      - BASE_URL=${BASE_URL:-http://localhost:8080}
+      - BASE_URL=${BASE_URL}
+      - REGISTRATION_ID=discord
     depends_on:
       mysql:
         condition: service_healthy

--- a/src/main/java/org/envyw/dadmarketplace/config/SecurityConfig.java
+++ b/src/main/java/org/envyw/dadmarketplace/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
         return http
                 .authorizeExchange(exchanges -> exchanges
                         .pathMatchers("/", "/api/auth/**", "/oauth2/**", "/api/search-keyword/**",
-                                "/api/proxy/darkerdb/**", "/favicon.ico", "/login/oauth2/code/discord",
+                                "/api/darkerdb/**", "/favicon.ico", "/login/oauth2/code/discord",
                                 "/debug/**").permitAll()
                         .anyExchange().authenticated())
                 .addFilterBefore(jwtAuthenticationWebFilter, SecurityWebFiltersOrder.AUTHENTICATION)

--- a/src/main/java/org/envyw/dadmarketplace/config/WebClientConfig.java
+++ b/src/main/java/org/envyw/dadmarketplace/config/WebClientConfig.java
@@ -1,0 +1,37 @@
+package org.envyw.dadmarketplace.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
+                .responseTimeout(Duration.ofSeconds(10))
+                .doOnConnected(conn ->
+                        conn.addHandlerLast(new ReadTimeoutHandler(10, TimeUnit.SECONDS))
+                                .addHandlerLast(new WriteTimeoutHandler(10, TimeUnit.SECONDS)));
+
+        ExchangeStrategies strategies = ExchangeStrategies.builder()
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(1024 * 1024))
+                .build();
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .exchangeStrategies(strategies)
+                .build();
+    }
+}

--- a/src/main/java/org/envyw/dadmarketplace/controller/DarkerDBController.java
+++ b/src/main/java/org/envyw/dadmarketplace/controller/DarkerDBController.java
@@ -1,0 +1,37 @@
+package org.envyw.dadmarketplace.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.envyw.dadmarketplace.service.ExternalApiService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/darkerdb")
+@RequiredArgsConstructor
+@Slf4j
+public class DarkerDBController {
+
+    private final ExternalApiService externalApiService;
+
+    @GetMapping("/**")
+    public Mono<ResponseEntity<Object>> proxyGetRequest(ServerHttpRequest request) {
+        String requestPath = request.getPath().value();
+        String proxyBasePath = "/api/proxy/darkerdb";
+
+        String targetPath = requestPath.substring(proxyBasePath.length());
+        if (targetPath.startsWith("/")) {
+            targetPath = targetPath.substring(1);
+        }
+
+        String queryString = request.getURI().getQuery();
+
+        log.info("프록시 요청 수신: path={}, queryString={}", targetPath, queryString);
+
+        return externalApiService.proxyGetRequest(targetPath, queryString);
+    }
+}

--- a/src/main/java/org/envyw/dadmarketplace/service/ExternalApiService.java
+++ b/src/main/java/org/envyw/dadmarketplace/service/ExternalApiService.java
@@ -1,0 +1,97 @@
+package org.envyw.dadmarketplace.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExternalApiService {
+
+    private static final String EXTERNAL_API_BASE_URL = "https://api.darkerdb.com/v1";
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+
+    private final WebClient webClient;
+
+    public Mono<ResponseEntity<Object>> proxyGetRequest(String path, String queryParams) {
+        if (!StringUtils.hasText(path)) {
+            log.warn("빈 경로로 외부 API 요청 시도");
+            return Mono.just(ResponseEntity.badRequest()
+                    .body(Map.of("error", "Path cannot be empty")));
+        }
+
+        String fullUrl = buildFullUrl(path, queryParams);
+        log.info("외부 API 요청 시작: {}", fullUrl);
+
+        return webClient.get()
+                .uri(fullUrl)
+                .retrieve()
+                .toEntity(Object.class)
+                .timeout(REQUEST_TIMEOUT)
+                .doOnSuccess(response -> log.info("외부 API 요청 성공: {} - Status: {}",
+                        fullUrl, response.getStatusCode()))
+                .onErrorResume(this::handleError);
+    }
+
+    private String buildFullUrl(String path, String queryParams) {
+        StringBuilder urlBuilder = new StringBuilder(EXTERNAL_API_BASE_URL);
+        urlBuilder.append("/").append(path.replaceAll("^/+", ""));
+
+        if (StringUtils.hasText(queryParams)) {
+            urlBuilder.append("?").append(queryParams);
+        }
+
+        return urlBuilder.toString();
+    }
+
+    private Mono<ResponseEntity<Object>> handleError(Throwable throwable) {
+        log.error("외부 API 요청 중 오류 발생", throwable);
+
+        if (throwable instanceof WebClientResponseException responseException) {
+            return handleWebClientResponseException(responseException);
+        }
+
+        if (throwable instanceof WebClientException) {
+            return Mono.just(ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .body(Map.of("error", "External API connection error: " + throwable.getMessage())));
+        }
+
+        return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("error", "Unexpected error occurred: " + throwable.getMessage())));
+    }
+
+    private Mono<ResponseEntity<Object>> handleWebClientResponseException(WebClientResponseException ex) {
+        HttpStatus status = (HttpStatus) ex.getStatusCode();
+        String errorMessage;
+        HttpStatus responseStatus;
+
+        if (status.is4xxClientError()) {
+            errorMessage = "External API client error: " + ex.getStatusText();
+            responseStatus = status;
+        } else if (status.is5xxServerError()) {
+            errorMessage = "External API server error: " + ex.getStatusText();
+            responseStatus = HttpStatus.BAD_GATEWAY;
+        } else {
+            errorMessage = "External API error: " + ex.getStatusText();
+            responseStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+
+        return Mono.just(ResponseEntity.status(responseStatus)
+                .body(Map.of(
+                        "error", errorMessage,
+                        "originalStatus", status.value(),
+                        "originalMessage", ex.getStatusText()
+                )));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,51 +7,6 @@ server:
 spring:
   application:
     name: dad-marketplace
-  cloud:
-    gateway:
-      routes:
-        # DarkerDB API 프록시 라우트
-        - id: darkerdb-proxy
-          uri: https://api.darkerdb.com
-          predicates:
-            - Path=/api/proxy/darkerdb/**
-          filters:
-            - StripPrefix=3
-            # RemoveRequestHeader를 사용해서 기존 헤더 제거 후 새로 추가
-            - RemoveRequestHeader=X-Forwarded-For
-            - PreserveHostHeader=true
-            # 간단한 고정 값 사용
-            - AddRequestHeader=X-Proxied-By, dad-marketplace
-            # CORS 응답 헤더
-            - AddResponseHeader=Access-Control-Allow-Origin, *
-            - AddResponseHeader=Access-Control-Allow-Methods, GET,POST,PUT,DELETE,OPTIONS
-            - AddResponseHeader=Access-Control-Allow-Headers, *
-
-      # CORS 글로벌 설정
-      globalcors:
-        corsConfigurations:
-          '[/**]':
-            allowedOriginPatterns:
-              - "http://localhost:*"
-              - "https://www.highrollermarket.com"
-            allowedMethods:
-              - GET
-              - POST
-              - PUT
-              - DELETE
-              - OPTIONS
-            allowedHeaders: "*"
-            allowCredentials: true
-            exposedHeaders:
-              - Content-Type
-              - Cache-Control
-              - ETag
-
-      # 타임아웃 설정
-      httpclient:
-        connect-timeout: 10000
-        response-timeout: 10s
-
   r2dbc:
     url: r2dbc:mysql://localhost:3307/${MYSQL_DATABASE}
     username: ${MYSQL_USER}


### PR DESCRIPTION
- Gateway 프록시 방식에서의 문제점 발견
  - Https 요청 자체를 프록시하기 떄문에 SSL/TLS 인증서 오류 발생
- Gateway를 사용하지 않고 직접 DarkerDB API용 API 구현
- /api/darkerdb 엔드포인트로 요청 시 DarkerDB API 요청 결과 응답