### PR TITLE
fix: DarkerDB 외부 API에 대한 substring 문제 해결

### DIFF
--- a/src/main/java/org/envyw/dadmarketplace/controller/DarkerDBController.java
+++ b/src/main/java/org/envyw/dadmarketplace/controller/DarkerDBController.java
@@ -21,7 +21,7 @@ public class DarkerDBController {
     @GetMapping("/**")
     public Mono<ResponseEntity<Object>> proxyGetRequest(ServerHttpRequest request) {
         String requestPath = request.getPath().value();
-        String proxyBasePath = "/api/proxy/darkerdb";
+        String proxyBasePath = "/api/darkerdb";
 
         String targetPath = requestPath.substring(proxyBasePath.length());
         if (targetPath.startsWith("/")) {


### PR DESCRIPTION
- substring할 URL이 /api/darkerdb 가 아닌 /api/proxy/darkerdb 로 구현된 문제 해결