### PR TITLE
이미 등록된 계정으로 디스코드 로그인 시도 시 토큰 발급이 안되는 오류 수정 

### DIFF
--- a/src/main/java/org/envyw/dadmarketplace/application/service/UserService.java
+++ b/src/main/java/org/envyw/dadmarketplace/application/service/UserService.java
@@ -42,8 +42,8 @@ public class UserService {
     }
 
     private Mono<User> updateUser(User user, DiscordUser discordUser) {
-        log.info("기존 사용자 정보 업데이트: discordId={}, username={}, userId={}",
-                discordUser.id(), discordUser.username(), user.getUserId());
+        log.info("기존 사용자 정보 업데이트: discordId={}, username={}, userId={}, userDiscordId={}",
+                discordUser.id(), discordUser.username(), user.getUserId(), user.getDiscordId());
 
         user.updateByDiscordUser(discordUser);
         return userRepository.save(user);
@@ -55,6 +55,5 @@ public class UserService {
 
         User newUser = UserFactory.fromDiscordUser(discordUser);
         return userRepository.save(newUser);
-
     }
 }

--- a/src/main/java/org/envyw/dadmarketplace/infrastructure/persistence/user/UserEntity.java
+++ b/src/main/java/org/envyw/dadmarketplace/infrastructure/persistence/user/UserEntity.java
@@ -68,6 +68,8 @@ public class UserEntity {
 
     public static UserEntity fromUser(User user) {
         return UserEntity.builder()
+                .id(user.getUserId())
+                .discordId(user.getDiscordId())
                 .username(user.getUsername())
                 .displayName(user.getDisplayName())
                 .email(user.getEmail())

--- a/src/test/java/org/envyw/dadmarketplace/application/service/UserServiceTest.java
+++ b/src/test/java/org/envyw/dadmarketplace/application/service/UserServiceTest.java
@@ -1,0 +1,100 @@
+package org.envyw.dadmarketplace.application.service;
+
+import org.envyw.dadmarketplace.application.repository.UserRepository;
+import org.envyw.dadmarketplace.domain.User;
+import org.envyw.dadmarketplace.infrastructure.security.dto.DiscordUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    private User createUserByDiscordUserId(String discordUserId) {
+        return User.builder()
+                .userId(123L)
+                .discordId(discordUserId)
+                .email("email@email.com")
+                .avatarUrl("https://avatar.url")
+                .username("testUsername")
+                .displayName("testDisplayName")
+                .build();
+    }
+
+    private DiscordUser createDiscordUser(String discordUserid) {
+        return DiscordUser.builder()
+                .id(discordUserid)
+                .email("email@email.com")
+                .avatarUrl("https://avatar.url")
+                .username("testUsername")
+                .displayName("testDisplayName")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("saveOrUpdateUser 메서드")
+    class SaveOrUpdateUserMethod {
+
+        @Test
+        @DisplayName("새로운 DiscordUser에 대해서는 새로운 User를 저장")
+        void shouldSaveNewUserWithNewDiscordUser() {
+            // Given
+            String newDiscordUserId = "123";
+            DiscordUser newDiscordUser = createDiscordUser(newDiscordUserId);
+            User newUser = createUserByDiscordUserId(newDiscordUserId);
+
+            when(userRepository.findByDiscordId(newDiscordUserId)).thenReturn(Mono.empty());
+            when(userRepository.save(any(User.class))).thenReturn(Mono.just(newUser));
+
+            // When
+            Mono<Long> newUserId = userService.saveOrUpdateUser(newDiscordUser);
+
+            // Then
+            StepVerifier.create(newUserId)
+                    .assertNext(userId -> assertThat(userId).isEqualTo(newUser.getUserId()))
+                    .verifyComplete();
+
+            verify(userRepository).findByDiscordId(newDiscordUserId);
+            verify(userRepository).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("이미 있는 DiscordUser에 대해서는 디스코드 정보를 업데이트")
+        void shouldUpdateUserWithExistDiscordUser() {
+            // Given
+            String existDiscorUserId = "123";
+            DiscordUser existDiscordUser = createDiscordUser(existDiscorUserId);
+            User existUser = createUserByDiscordUserId(existDiscorUserId);
+
+            when(userRepository.findByDiscordId(existDiscorUserId)).thenReturn(Mono.just(existUser));
+            when(userRepository.save(any(User.class))).thenReturn(Mono.just(existUser));
+
+            // When
+            Mono<Long> existUserId = userService.saveOrUpdateUser(existDiscordUser);
+
+            // Then
+            StepVerifier.create(existUserId)
+                    .assertNext(userId -> assertThat(userId).isEqualTo(existUser.getUserId()))
+                    .verifyComplete();
+
+            verify(userRepository).findByDiscordId(existDiscorUserId);
+            verify(userRepository).save(any(User.class));
+        }
+    }
+}


### PR DESCRIPTION
- 문제 원인: Domain -> Persistence Entity 변환 과정에서 id가 누락되어 INSERT 쿼리가 발생
- 해결 방법: Domain 매핑 시 id와 DiscordId 모두 반영하도록 수정